### PR TITLE
refactor: Replace setState with ValueNotifier for scoped rebuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,11 @@
 ```
 lib/
 ├── story_maker.dart              # Main entry point: StoryMaker StatefulWidget + exports
-├── components/                   # Reusable UI widgets
+├── controller/                   # State management
+│   ├── controller.dart           # Barrel export
+│   └── src/
+│       └── story_maker_controller.dart  # ValueNotifier-based state controller
+├── components/                   # Reusable UI widgets (all StatelessWidget)
 │   ├── components.dart           # Barrel export
 │   └── src/
 │       ├── background_gradient_selector_widget.dart
@@ -29,17 +33,17 @@ lib/
 ├── constants/                    # Enums, palettes, gradients, stickers
 │   ├── constants.dart            # Barrel export
 │   └── src/
-│       ├── color_filters.dart    # ColorFilterType enum + filter matrices
+│       ├── color_filters.dart    # ColorFilterType enum with matrix/displayName methods
 │       ├── font_colors.dart      # Default text colors
 │       ├── font_styles.dart      # Default Google Fonts list
-│       ├── gradients.dart        # 60+ gradient presets
+│       ├── gradients.dart        # 50+ gradient presets
 │       ├── item_type.dart        # ItemType enum (IMAGE, TEXT, STICKER)
-│       ├── stickers.dart         # 50+ emoji stickers
+│       ├── stickers.dart         # 48 emoji stickers
 │       └── ui_constants.dart     # UI magic numbers
 ├── models/                       # Data models
 │   ├── models.dart               # Barrel export
 │   └── src/
-│       ├── editable_items.dart   # EditableItem (position, scale, rotation, text)
+│       ├── editable_items.dart   # EditableItem (immutable, with copyWith)
 │       └── sticker_item.dart     # StickerItem (emoji or image/GIF)
 ├── theme/                        # Theming system
 │   ├── theme.dart                # Barrel export
@@ -91,8 +95,35 @@ Every directory under `lib/` has a barrel file (e.g., `components/components.dar
 
 ### State Management
 
-- **Local state** via `StatefulWidget` + `setState` — no external state management packages
+- **ValueNotifier + ValueListenableBuilder** — all mutable state lives in `StoryMakerController` as individual `ValueNotifier` instances. The main widget uses `ValueListenableBuilder` to scope rebuilds to only the widgets that depend on each piece of state.
+- **No setState** — the codebase has zero `setState` calls. All state mutations go through `ValueNotifier.value = ...` on the controller.
 - **Theme propagation** via `InheritedWidget` (`StoryMakerThemeProvider`)
+
+### StoryMakerController
+
+`lib/controller/src/story_maker_controller.dart` owns all mutable state:
+
+| ValueNotifier | Type | Purpose |
+|---|---|---|
+| `stackData` | `List<EditableItem>` | All items on the canvas |
+| `activeItem` | `EditableItem?` | Currently selected item |
+| `isTextInput` | `bool` | Text editing mode |
+| `isDeletePosition` | `bool` | Item over delete zone |
+| `selectedTextColor` | `Color` | Current text color |
+| `selectedTextBackgroundGradient` | `int` | Text background gradient index |
+| `selectedFontSize` | `double` | Font size |
+| `selectedFontFamily` | `int` | Font family index |
+| `isColorPickerSelected` | `bool` | Text color picker visibility |
+| `isBackgroundColorPickerSelected` | `bool` | Background gradient picker visibility |
+| `isStickerPickerSelected` | `bool` | Sticker picker visibility |
+| `isColorFilterPickerSelected` | `bool` | Color filter picker visibility |
+| `selectedColorFilter` | `ColorFilterType` | Active color filter |
+| `selectedBackgroundGradient` | `int` | Background gradient index |
+| `isLoading` | `bool` | Export loading state |
+| `displayedStyleName` | `String?` | Temporary style name overlay |
+| `displayedFilterName` | `String?` | Temporary filter name overlay |
+
+Non-reactive state (gesture tracking: `_initPos`, `_currentPos`, `_currentScale`, `_currentRotation`, `_inAction`) stays as plain fields since they don't drive UI rebuilds.
 
 ### Main Entry Point
 
@@ -102,9 +133,27 @@ Every directory under `lib/` has a barrel file (e.g., `components/components.dar
 - `customFontList`, `customTextColors`, `customGradients`, `customStickers` — override defaults
 - `doneButtonBuilder` — custom done button with theme, callback, and loading state
 
+### Immutable Models
+
+`EditableItem` is `@immutable` with `const` constructor, `copyWith()`, and `==`/`hashCode`. To update an item, create a new copy and replace it in the list:
+```dart
+final updated = item.copyWith(position: newPos);
+final items = List<EditableItem>.from(stackData.value);
+items[idx] = updated;
+stackData.value = items;
+```
+
 ### Public API Surface
 
-Exported classes: `StoryMaker`, `EditableItem`, `StickerItem`, `StoryMakerTheme`, `StoryMakerThemeProvider`, `ColorFilterType`, `ItemType`
+Exported classes: `StoryMaker`, `StoryMakerController`, `EditableItem`, `StickerItem`, `StoryMakerTheme`, `StoryMakerThemeProvider`, `ColorFilterType`, `ItemType`
+
+### ColorFilterType Enum
+
+Filters expose their data via enum methods — no free functions needed:
+```dart
+filter.matrix       // List<double> color matrix
+filter.displayName  // Human-readable name
+```
 
 ## Code Style & Conventions
 
@@ -133,6 +182,7 @@ These lint violations are treated as **errors** and will fail analysis:
 - No code generation — all models are hand-written
 - Avoid `dynamic` types (`avoid_annotating_with_dynamic`)
 - Use `omit_local_variable_types` — let Dart infer local types
+- All component widgets are `StatelessWidget` — state flows in via constructor params from `ValueListenableBuilder`
 
 ## Dependencies
 

--- a/lib/constants/src/color_filters.dart
+++ b/lib/constants/src/color_filters.dart
@@ -22,11 +22,46 @@ enum ColorFilterType {
   bright,
 
   /// Dark filter.
-  dark,
+  dark;
+
+  /// Gets the 5x4 color matrix for this filter type.
+  List<double> get matrix {
+    return switch (this) {
+      ColorFilterType.none => _identityMatrix,
+      ColorFilterType.sepia => _sepiaMatrix,
+      ColorFilterType.grayscale => _grayscaleMatrix,
+      ColorFilterType.vintage => _vintageMatrix,
+      ColorFilterType.cool => _coolMatrix,
+      ColorFilterType.warm => _warmMatrix,
+      ColorFilterType.bright => _brightMatrix,
+      ColorFilterType.dark => _darkMatrix,
+    };
+  }
+
+  /// Gets the human-readable display name for this filter.
+  String get displayName {
+    return switch (this) {
+      ColorFilterType.none => 'None',
+      ColorFilterType.sepia => 'Sepia',
+      ColorFilterType.grayscale => 'Grayscale',
+      ColorFilterType.vintage => 'Vintage',
+      ColorFilterType.cool => 'Cool',
+      ColorFilterType.warm => 'Warm',
+      ColorFilterType.bright => 'Bright',
+      ColorFilterType.dark => 'Dark',
+    };
+  }
 }
 
+const List<double> _identityMatrix = [
+  1, 0, 0, 0, 0,
+  0, 1, 0, 0, 0,
+  0, 0, 1, 0, 0,
+  0, 0, 0, 1, 0,
+];
+
 /// Color filter matrix for sepia effect.
-const List<double> sepiaMatrix = [
+const List<double> _sepiaMatrix = [
   0.393, 0.769, 0.189, 0, 0,
   0.349, 0.686, 0.168, 0, 0,
   0.272, 0.534, 0.131, 0, 0,
@@ -34,7 +69,7 @@ const List<double> sepiaMatrix = [
 ];
 
 /// Color filter matrix for grayscale effect.
-const List<double> grayscaleMatrix = [
+const List<double> _grayscaleMatrix = [
   0.2126, 0.7152, 0.0722, 0, 0,
   0.2126, 0.7152, 0.0722, 0, 0,
   0.2126, 0.7152, 0.0722, 0, 0,
@@ -42,7 +77,7 @@ const List<double> grayscaleMatrix = [
 ];
 
 /// Color filter matrix for vintage effect.
-const List<double> vintageMatrix = [
+const List<double> _vintageMatrix = [
   0.9, 0.5, 0.1, 0, 0,
   0.3, 0.8, 0.1, 0, 0,
   0.2, 0.3, 0.5, 0, 0,
@@ -50,7 +85,7 @@ const List<double> vintageMatrix = [
 ];
 
 /// Color filter matrix for cool effect (blue tint).
-const List<double> coolMatrix = [
+const List<double> _coolMatrix = [
   1, 0, 0, 0, 0,
   0, 1, 0.1, 0, 0,
   0, 0.1, 1, 0, 0,
@@ -58,7 +93,7 @@ const List<double> coolMatrix = [
 ];
 
 /// Color filter matrix for warm effect (orange/red tint).
-const List<double> warmMatrix = [
+const List<double> _warmMatrix = [
   1, 0.1, 0, 0, 0,
   0, 1, 0, 0, 0,
   0, 0, 0.9, 0, 0,
@@ -66,7 +101,7 @@ const List<double> warmMatrix = [
 ];
 
 /// Color filter matrix for bright effect.
-const List<double> brightMatrix = [
+const List<double> _brightMatrix = [
   1.2, 0, 0, 0, 0,
   0, 1.2, 0, 0, 0,
   0, 0, 1.2, 0, 0,
@@ -74,7 +109,7 @@ const List<double> brightMatrix = [
 ];
 
 /// Color filter matrix for dark effect.
-const List<double> darkMatrix = [
+const List<double> _darkMatrix = [
   0.7, 0, 0, 0, 0,
   0, 0.7, 0, 0, 0,
   0, 0, 0.7, 0, 0,
@@ -82,51 +117,12 @@ const List<double> darkMatrix = [
 ];
 
 /// Gets the color filter matrix for a given filter type.
-List<double> getColorFilterMatrix(ColorFilterType filterType) {
-  switch (filterType) {
-    case ColorFilterType.sepia:
-      return sepiaMatrix;
-    case ColorFilterType.grayscale:
-      return grayscaleMatrix;
-    case ColorFilterType.vintage:
-      return vintageMatrix;
-    case ColorFilterType.cool:
-      return coolMatrix;
-    case ColorFilterType.warm:
-      return warmMatrix;
-    case ColorFilterType.bright:
-      return brightMatrix;
-    case ColorFilterType.dark:
-      return darkMatrix;
-    case ColorFilterType.none:
-      return [
-        1, 0, 0, 0, 0,
-        0, 1, 0, 0, 0,
-        0, 0, 1, 0, 0,
-        0, 0, 0, 1, 0,
-      ];
-  }
-}
+///
+/// Deprecated: Use [ColorFilterType.matrix] instead.
+List<double> getColorFilterMatrix(ColorFilterType filterType) =>
+    filterType.matrix;
 
 /// Gets the display name for a filter type.
-String getFilterName(ColorFilterType filterType) {
-  switch (filterType) {
-    case ColorFilterType.none:
-      return 'None';
-    case ColorFilterType.sepia:
-      return 'Sepia';
-    case ColorFilterType.grayscale:
-      return 'Grayscale';
-    case ColorFilterType.vintage:
-      return 'Vintage';
-    case ColorFilterType.cool:
-      return 'Cool';
-    case ColorFilterType.warm:
-      return 'Warm';
-    case ColorFilterType.bright:
-      return 'Bright';
-    case ColorFilterType.dark:
-      return 'Dark';
-  }
-}
-
+///
+/// Deprecated: Use [ColorFilterType.displayName] instead.
+String getFilterName(ColorFilterType filterType) => filterType.displayName;

--- a/lib/constants/src/gradients.dart
+++ b/lib/constants/src/gradients.dart
@@ -25,7 +25,6 @@ const List<List<Color>> gradientColors = [
   [Color(0xFF1488CC), Color(0xFF2B32B2)],
   [Color(0xFFec008c), Color(0xFFfc6767)],
   [Color(0xFFcc2b5e), Color(0xFF753a88)],
-  [Color(0xFF2193b0), Color(0xFF6dd5ed)],
   [Color(0xFF2b5876), Color(0xFF4e4376)],
   [Color(0xFFff6e7f), Color(0xFFbfe9ff)],
   [Color(0xFFe52d27), Color(0xFFb31217)],

--- a/lib/constants/src/stickers.dart
+++ b/lib/constants/src/stickers.dart
@@ -50,8 +50,4 @@ const List<String> defaultStickers = [
   '🎺',
   '🎻',
   '🎷',
-  '🎪',
-  '🎭',
-  '🎨',
-  '🎬',
 ];

--- a/lib/controller/controller.dart
+++ b/lib/controller/controller.dart
@@ -1,0 +1,6 @@
+/// Barrel file for controllers.
+///
+/// This file exports all public controller classes used throughout the story_maker package.
+library;
+
+export 'src/story_maker_controller.dart';

--- a/lib/controller/src/story_maker_controller.dart
+++ b/lib/controller/src/story_maker_controller.dart
@@ -1,0 +1,510 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../constants/constants.dart';
+import '../../models/models.dart';
+
+/// Manages all mutable state for the StoryMaker widget using ValueNotifiers.
+///
+/// Each piece of state is a separate ValueNotifier so that only the widgets
+/// that depend on a particular value rebuild when it changes.
+class StoryMakerController {
+  StoryMakerController({
+    required String filePath,
+    required List<String> fontList,
+    required List<Color> textColors,
+    required List<List<Color>> gradients,
+  })  : _fontList = fontList,
+        _textColors = textColors,
+        _gradients = gradients {
+    _stackData.value = [
+      EditableItem(type: ItemType.IMAGE, value: filePath),
+    ];
+    familyPageController = PageController(
+      viewportFraction: ViewportFractions.fontFamily,
+    );
+    textColorsPageController = PageController(
+      viewportFraction: ViewportFractions.textColors,
+    );
+    gradientsPageController = PageController(
+      viewportFraction: ViewportFractions.gradients,
+    );
+    colorFiltersPageController = PageController(
+      viewportFraction: 0.15,
+      initialPage: selectedColorFilter.value.index,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Configuration (immutable after construction)
+  // ---------------------------------------------------------------------------
+
+  final List<String> _fontList;
+  final List<Color> _textColors;
+  final List<List<Color>> _gradients;
+
+  // ---------------------------------------------------------------------------
+  // Canvas items
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<List<EditableItem>> _stackData =
+      ValueNotifier<List<EditableItem>>([]);
+
+  ValueNotifier<List<EditableItem>> get stackData => _stackData;
+
+  // ---------------------------------------------------------------------------
+  // Active / gesture state
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<EditableItem?> activeItem =
+      ValueNotifier<EditableItem?>(null);
+
+  final ValueNotifier<bool> isDeletePosition = ValueNotifier<bool>(false);
+
+  Offset _initPos = Offset.zero;
+  Offset _currentPos = Offset.zero;
+  double _currentScale = 1;
+  double _currentRotation = 0;
+  bool _inAction = false;
+
+  bool get inAction => _inAction;
+
+  // ---------------------------------------------------------------------------
+  // Text editing state
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<bool> isTextInput = ValueNotifier<bool>(false);
+
+  final ValueNotifier<Color> selectedTextColor =
+      ValueNotifier<Color>(const Color(0xffffffff));
+
+  final ValueNotifier<int> selectedTextBackgroundGradient =
+      ValueNotifier<int>(0);
+
+  final ValueNotifier<double> selectedFontSize =
+      ValueNotifier<double>(FontSizeConstants.defaultValue);
+
+  final ValueNotifier<int> selectedFontFamily = ValueNotifier<int>(0);
+
+  final ValueNotifier<bool> isColorPickerSelected =
+      ValueNotifier<bool>(false);
+
+  String currentText = '';
+
+  final TextEditingController editingController = TextEditingController();
+
+  // ---------------------------------------------------------------------------
+  // Picker visibility
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<bool> isBackgroundColorPickerSelected =
+      ValueNotifier<bool>(false);
+
+  final ValueNotifier<bool> isStickerPickerSelected =
+      ValueNotifier<bool>(false);
+
+  final ValueNotifier<bool> isColorFilterPickerSelected =
+      ValueNotifier<bool>(false);
+
+  // ---------------------------------------------------------------------------
+  // Filter & gradient state
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<ColorFilterType> selectedColorFilter =
+      ValueNotifier<ColorFilterType>(ColorFilterType.none);
+
+  final ValueNotifier<int> selectedBackgroundGradient =
+      ValueNotifier<int>(0);
+
+  // ---------------------------------------------------------------------------
+  // Loading
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<bool> isLoading = ValueNotifier<bool>(false);
+
+  // ---------------------------------------------------------------------------
+  // Overlay name display (style / filter name)
+  // ---------------------------------------------------------------------------
+
+  final ValueNotifier<String?> displayedStyleName =
+      ValueNotifier<String?>(null);
+
+  final ValueNotifier<String?> displayedFilterName =
+      ValueNotifier<String?>(null);
+
+  Timer? _styleNameTimer;
+  Timer? _filterNameTimer;
+
+  // ---------------------------------------------------------------------------
+  // Page controllers
+  // ---------------------------------------------------------------------------
+
+  late final PageController familyPageController;
+  late final PageController textColorsPageController;
+  late final PageController gradientsPageController;
+  late final PageController colorFiltersPageController;
+
+  // ---------------------------------------------------------------------------
+  // Text editing actions
+  // ---------------------------------------------------------------------------
+
+  void onTextChange(String input) {
+    currentText = input;
+  }
+
+  void onTextSubmit(String input) {
+    if (input.isNotEmpty) {
+      _submitText();
+    } else {
+      currentText = '';
+    }
+    isTextInput.value = !isTextInput.value;
+    activeItem.value = null;
+  }
+
+  void _submitText() {
+    final items = List<EditableItem>.from(_stackData.value)
+      ..add(
+        EditableItem(
+          type: ItemType.TEXT,
+          value: currentText,
+          color: selectedTextColor.value,
+          textStyle: selectedTextBackgroundGradient.value,
+          fontSize: selectedFontSize.value,
+          fontFamily: selectedFontFamily.value,
+        ),
+      );
+    _stackData.value = items;
+    editingController.text = '';
+    currentText = '';
+  }
+
+  void onChangeTextBackground() {
+    if (selectedTextBackgroundGradient.value < _gradients.length - 1) {
+      selectedTextBackgroundGradient.value++;
+    } else {
+      selectedTextBackgroundGradient.value = 0;
+    }
+  }
+
+  void onToggleTextColorSelector() {
+    isColorPickerSelected.value = !isColorPickerSelected.value;
+  }
+
+  void onTextColorChange(int index) {
+    HapticFeedback.lightImpact();
+    selectedTextColor.value = _textColors[index];
+  }
+
+  void onFamilyChange(int index) {
+    HapticFeedback.lightImpact();
+    selectedFontFamily.value = index;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Picker toggles
+  // ---------------------------------------------------------------------------
+
+  void onToggleBackgroundGradientPicker() {
+    isBackgroundColorPickerSelected.value =
+        !isBackgroundColorPickerSelected.value;
+    isStickerPickerSelected.value = false;
+    isColorFilterPickerSelected.value = false;
+  }
+
+  void onToggleStickerPicker() {
+    isStickerPickerSelected.value = !isStickerPickerSelected.value;
+    isBackgroundColorPickerSelected.value = false;
+    isColorFilterPickerSelected.value = false;
+    isTextInput.value = false;
+    activeItem.value = null;
+  }
+
+  void onToggleColorFilterPicker() {
+    isColorFilterPickerSelected.value =
+        !isColorFilterPickerSelected.value;
+    isBackgroundColorPickerSelected.value = false;
+    isStickerPickerSelected.value = false;
+    isTextInput.value = false;
+    activeItem.value = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filter actions
+  // ---------------------------------------------------------------------------
+
+  void onColorFilterSelected(ColorFilterType filter) {
+    HapticFeedback.lightImpact();
+    _filterNameTimer?.cancel();
+
+    selectedColorFilter.value = filter;
+    isColorFilterPickerSelected.value = false;
+    displayedFilterName.value = filter.displayName;
+
+    _filterNameTimer = Timer(const Duration(seconds: 2), () {
+      displayedFilterName.value = null;
+    });
+
+    if (colorFiltersPageController.hasClients) {
+      colorFiltersPageController.jumpToPage(filter.index);
+    }
+  }
+
+  void onHorizontalDragEnd(
+    DragEndDetails details, {
+    required bool hasActiveItem,
+  }) {
+    if (_inAction || isTextInput.value || hasActiveItem) {
+      return;
+    }
+
+    final velocity = details.velocity.pixelsPerSecond.dx;
+    const threshold = 300.0;
+
+    if (velocity.abs() > threshold) {
+      final filters = ColorFilterType.values;
+      final currentIndex = selectedColorFilter.value.index;
+      _filterNameTimer?.cancel();
+
+      final nextIndex = velocity > 0
+          ? (currentIndex + 1) % filters.length
+          : (currentIndex - 1 + filters.length) % filters.length;
+      final filter = filters[nextIndex];
+
+      HapticFeedback.lightImpact();
+      selectedColorFilter.value = filter;
+      displayedFilterName.value = filter.displayName;
+
+      _filterNameTimer = Timer(const Duration(seconds: 2), () {
+        displayedFilterName.value = null;
+      });
+
+      if (colorFiltersPageController.hasClients) {
+        colorFiltersPageController.jumpToPage(nextIndex);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sticker actions
+  // ---------------------------------------------------------------------------
+
+  void onStickerSelected(StickerItem sticker) {
+    final items = List<EditableItem>.from(_stackData.value)
+      ..add(
+        EditableItem(
+          type: ItemType.STICKER,
+          value: sticker.value,
+          fontSize: FontSizeConstants.defaultValue,
+        ),
+      );
+    _stackData.value = items;
+    isStickerPickerSelected.value = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Background gradient actions
+  // ---------------------------------------------------------------------------
+
+  void onBackgroundGradientTap(int index) {
+    selectedBackgroundGradient.value = index;
+    gradientsPageController.jumpToPage(index);
+  }
+
+  void onChangeBackgroundGradient(int index) {
+    HapticFeedback.lightImpact();
+    selectedBackgroundGradient.value = index;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Gesture handling
+  // ---------------------------------------------------------------------------
+
+  void onScaleStart(ScaleStartDetails details) {
+    final item = activeItem.value;
+    if (item == null) return;
+    _initPos = details.focalPoint;
+    _currentPos = item.position;
+    _currentScale = item.scale;
+    _currentRotation = item.rotation;
+  }
+
+  void onScaleUpdate(ScaleUpdateDetails details, Size canvasSize) {
+    final item = activeItem.value;
+    if (item == null) return;
+    final delta = details.focalPoint - _initPos;
+    final left = (delta.dx / canvasSize.width) + _currentPos.dx;
+    final top = (delta.dy / canvasSize.height) + _currentPos.dy;
+
+    final updated = item.copyWith(
+      position: Offset(left, top),
+      rotation: details.rotation + _currentRotation,
+      scale: details.scale * _currentScale,
+    );
+
+    // Replace the item in the stack
+    final items = List<EditableItem>.from(_stackData.value);
+    final idx = items.indexOf(item);
+    if (idx != -1) {
+      items[idx] = updated;
+      _stackData.value = items;
+    }
+    activeItem.value = updated;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Screen tap
+  // ---------------------------------------------------------------------------
+
+  void onScreenTap() {
+    isTextInput.value = !isTextInput.value;
+    activeItem.value = null;
+    isBackgroundColorPickerSelected.value = false;
+    isStickerPickerSelected.value = false;
+
+    if (currentText.isNotEmpty) {
+      _submitText();
+    }
+
+    familyPageController.dispose();
+    textColorsPageController.dispose();
+    familyPageController = PageController(
+      initialPage: selectedFontFamily.value,
+      viewportFraction: ViewportFractions.fontFamily,
+    );
+    textColorsPageController = PageController(
+      initialPage: _textColors.indexWhere(
+        (element) => element == selectedTextColor.value,
+      ),
+      viewportFraction: ViewportFractions.textColors,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Style / font change with overlay
+  // ---------------------------------------------------------------------------
+
+  void onStyleChange(int index) {
+    HapticFeedback.lightImpact();
+    _styleNameTimer?.cancel();
+
+    selectedFontFamily.value = index;
+    displayedStyleName.value = _fontList[index];
+
+    _styleNameTimer = Timer(const Duration(seconds: 2), () {
+      displayedStyleName.value = null;
+    });
+
+    if (familyPageController.hasClients) {
+      familyPageController.jumpToPage(index);
+    }
+  }
+
+  void onColorChange(int index) {
+    HapticFeedback.lightImpact();
+    selectedTextColor.value = _textColors[index];
+    textColorsPageController.jumpToPage(index);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Overlay item interaction
+  // ---------------------------------------------------------------------------
+
+  void onOverlayItemTap(EditableItem e) {
+    isTextInput.value = !isTextInput.value;
+    activeItem.value = null;
+    editingController.text = e.value;
+    currentText = e.value;
+    selectedFontFamily.value = e.fontFamily;
+    selectedFontSize.value = e.fontSize;
+    selectedTextBackgroundGradient.value = e.textStyle;
+    selectedTextColor.value = e.color;
+
+    final items = List<EditableItem>.from(_stackData.value)..remove(e);
+    _stackData.value = items;
+
+    familyPageController.dispose();
+    textColorsPageController.dispose();
+    familyPageController = PageController(
+      initialPage: e.fontFamily,
+      viewportFraction: ViewportFractions.fontFamily,
+    );
+    textColorsPageController = PageController(
+      initialPage: _textColors.indexWhere(
+        (element) => element == e.color,
+      ),
+      viewportFraction: ViewportFractions.textColors,
+    );
+  }
+
+  void onOverlayItemPointerDown(EditableItem e, PointerDownEvent details) {
+    if (e.type != ItemType.IMAGE) {
+      if (_inAction) return;
+      _inAction = true;
+      activeItem.value = e;
+      _initPos = details.position;
+      _currentPos = e.position;
+      _currentScale = e.scale;
+      _currentRotation = e.rotation;
+    }
+  }
+
+  void onOverlayItemPointerUp(EditableItem e, PointerUpEvent details) {
+    _inAction = false;
+    if (e.position.dy >= PositionConstants.deletePositionThreshold &&
+        e.position.dx >= 0.0 &&
+        e.position.dx <= 1.0) {
+      final items = List<EditableItem>.from(_stackData.value)..remove(e);
+      _stackData.value = items;
+      activeItem.value = null;
+    } else {
+      activeItem.value = null;
+    }
+    isDeletePosition.value = false;
+  }
+
+  void onOverlayItemPointerMove(EditableItem e, PointerMoveEvent details) {
+    final inDeleteZone = e.position.dy >=
+            PositionConstants.deletePositionThreshold &&
+        e.position.dx >= 0.0 &&
+        e.position.dx <= 1.0;
+    if (isDeletePosition.value != inDeleteZone) {
+      isDeletePosition.value = inDeleteZone;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Disposal
+  // ---------------------------------------------------------------------------
+
+  void dispose() {
+    editingController.dispose();
+    familyPageController.dispose();
+    textColorsPageController.dispose();
+    gradientsPageController.dispose();
+    colorFiltersPageController.dispose();
+    _styleNameTimer?.cancel();
+    _filterNameTimer?.cancel();
+
+    // Dispose all ValueNotifiers
+    _stackData.dispose();
+    activeItem.dispose();
+    isDeletePosition.dispose();
+    isTextInput.dispose();
+    selectedTextColor.dispose();
+    selectedTextBackgroundGradient.dispose();
+    selectedFontSize.dispose();
+    selectedFontFamily.dispose();
+    isColorPickerSelected.dispose();
+    isBackgroundColorPickerSelected.dispose();
+    isStickerPickerSelected.dispose();
+    isColorFilterPickerSelected.dispose();
+    selectedColorFilter.dispose();
+    selectedBackgroundGradient.dispose();
+    isLoading.dispose();
+    displayedStyleName.dispose();
+    displayedFilterName.dispose();
+  }
+}

--- a/lib/models/src/editable_items.dart
+++ b/lib/models/src/editable_items.dart
@@ -3,56 +3,104 @@ import 'package:flutter/material.dart';
 import '../../constants/src/item_type.dart';
 import '../../constants/src/ui_constants.dart';
 
-/// A class representing an editable item.
+/// A class representing an editable item on the story canvas.
 ///
-/// An editable item can be a text or an image that can be manipulated by the user.
-/// It has several properties that define its state, such as position, scale, rotation, type, value, color, textStyle, fontSize, and fontFamily.
+/// An editable item can be text, an image, or a sticker that the user
+/// can manipulate via gestures (drag, rotate, scale).
+@immutable
 class EditableItem {
-  /// The position of the item on the screen.
-  ///
-  /// This is represented as an Offset, where the x and y values are the horizontal and vertical distances from the top left corner of the screen.
-  Offset position = const Offset(
-    PositionConstants.defaultTextPositionX,
-    PositionConstants.defaultTextPositionY,
-  );
+  const EditableItem({
+    this.position = const Offset(
+      PositionConstants.defaultTextPositionX,
+      PositionConstants.defaultTextPositionY,
+    ),
+    this.scale = 1,
+    this.rotation = 0,
+    this.type = ItemType.TEXT,
+    this.value = '',
+    this.color = Colors.transparent,
+    this.textStyle = 0,
+    this.fontSize = FontSizeConstants.defaultValue,
+    this.fontFamily = 0,
+  });
 
-  /// The scale of the item.
-  ///
-  /// This is a double value that represents the size of the item relative to its original size.
-  double scale = 1;
+  /// The position of the item as a fraction of the canvas size.
+  final Offset position;
 
-  /// The rotation of the item.
-  ///
-  /// This is a double value that represents the rotation angle of the item in degrees.
-  double rotation = 0;
+  /// The scale factor relative to the original size.
+  final double scale;
 
-  /// The type of the item.
-  ///
-  /// This is an enum value of type ItemType, which can be either TEXT or IMAGE.
-  ItemType type = ItemType.TEXT;
+  /// The rotation angle in radians.
+  final double rotation;
 
-  /// The value of the item.
-  ///
-  /// For a text item, this is the text content. For an image item, this could be the image URL or asset path.
-  String value = '';
+  /// The type of the item (TEXT, IMAGE, or STICKER).
+  final ItemType type;
 
-  /// The color of the item.
-  ///
-  /// This is a Color value that represents the color of the item. For a text item, this is the text color.
-  Color color = Colors.transparent;
+  /// The content value — text content, file path, or emoji string.
+  final String value;
 
-  /// The style of the text.
-  ///
-  /// This is an integer value that represents the index of the text style in a predefined list of text styles.
-  int textStyle = 0;
+  /// The color of the item. For text items, this is the text color.
+  final Color color;
 
-  /// The font size of the text.
-  ///
-  /// This is a double value that represents the size of the text in logical pixels.
-  double fontSize = FontSizeConstants.defaultValue;
+  /// The index of the text background gradient style.
+  final int textStyle;
 
-  /// The font family of the text.
-  ///
-  /// This is an integer value that represents the index of the font family in a predefined list of font families.
-  int fontFamily = 0;
+  /// The font size in logical pixels.
+  final double fontSize;
+
+  /// The index of the font family in the font list.
+  final int fontFamily;
+
+  /// Creates a copy with the given fields replaced.
+  EditableItem copyWith({
+    Offset? position,
+    double? scale,
+    double? rotation,
+    ItemType? type,
+    String? value,
+    Color? color,
+    int? textStyle,
+    double? fontSize,
+    int? fontFamily,
+  }) {
+    return EditableItem(
+      position: position ?? this.position,
+      scale: scale ?? this.scale,
+      rotation: rotation ?? this.rotation,
+      type: type ?? this.type,
+      value: value ?? this.value,
+      color: color ?? this.color,
+      textStyle: textStyle ?? this.textStyle,
+      fontSize: fontSize ?? this.fontSize,
+      fontFamily: fontFamily ?? this.fontFamily,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EditableItem &&
+          runtimeType == other.runtimeType &&
+          position == other.position &&
+          scale == other.scale &&
+          rotation == other.rotation &&
+          type == other.type &&
+          value == other.value &&
+          color == other.color &&
+          textStyle == other.textStyle &&
+          fontSize == other.fontSize &&
+          fontFamily == other.fontFamily;
+
+  @override
+  int get hashCode => Object.hash(
+        position,
+        scale,
+        rotation,
+        type,
+        value,
+        color,
+        textStyle,
+        fontSize,
+        fontFamily,
+      );
 }

--- a/lib/story_maker.dart
+++ b/lib/story_maker.dart
@@ -4,26 +4,25 @@
 /// stories, including text editing, image manipulation, and more.
 library story_maker;
 
-import 'dart:async';
-import 'dart:developer';
 import 'dart:io';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:photo_view/photo_view.dart';
 
 import 'components/components.dart';
 import 'constants/constants.dart';
+import 'controller/controller.dart';
 import 'extensions/extensions.dart';
 import 'models/models.dart';
 import 'theme/theme.dart';
 
 export 'components/components.dart';
 export 'constants/constants.dart';
+export 'controller/controller.dart';
 export 'extensions/extensions.dart';
 export 'models/models.dart';
 export 'theme/theme.dart';
@@ -65,98 +64,9 @@ class StoryMaker extends StatefulWidget {
 }
 
 class _StoryMakerState extends State<StoryMaker> {
-// A global key used to get the context of the widget tree.
-  GlobalKey previewContainer = GlobalKey();
+  final GlobalKey _previewContainer = GlobalKey();
 
-// The currently active editable item.
-  EditableItem? _activeItem;
-
-// The initial position of the active item.
-  Offset _initPos = Offset.zero;
-
-// The current position of the active item.
-  Offset _currentPos = Offset.zero;
-
-// The current scale of the active item.
-  double _currentScale = 1;
-
-// The current rotation of the active item.
-  double _currentRotation = 0;
-
-// Indicates whether the widget is in action.
-  bool _inAction = false;
-
-// Indicates whether the widget is in text input mode.
-  bool _isTextInput = false;
-
-// The current text in the text input field.
-  String _currentText = '';
-
-// The currently selected text color.
-  Color _selectedTextColor = const Color(0xffffffff);
-
-// The index of the currently selected text background gradient.
-  int _selectedTextBackgroundGradient = 0;
-
-// The index of the currently selected background gradient.
-  int _selectedBackgroundGradient = 0;
-
-// The currently selected font size.
-  double _selectedFontSize = FontSizeConstants.defaultValue;
-
-// The index of the currently selected font family.
-  int _selectedFontFamily = 0;
-
-// Indicates whether the widget is in delete position.
-  bool _isDeletePosition = false;
-
-// Indicates whether the color picker is selected.
-  bool _isColorPickerSelected = false;
-
-// Indicates whether the background color picker is selected.
-  bool _isBackgroundColorPickerSelected = false;
-
-// Indicates whether the sticker picker is selected.
-  bool _isStickerPickerSelected = false;
-
-// Indicates whether the color filter picker is selected.
-  bool _isColorFilterPickerSelected = false;
-
-// The currently selected color filter.
-  ColorFilterType _selectedColorFilter = ColorFilterType.none;
-
-// Indicates whether the widget is in loading state.
-  bool _isLoading = false;
-
-// The currently displayed style name (for showing style name overlay).
-  String? _displayedStyleName;
-
-// Timer for hiding the style name overlay.
-  Timer? _styleNameTimer;
-
-// The currently displayed filter name (for showing filter name overlay).
-  String? _displayedFilterName;
-
-// Timer for hiding the filter name overlay.
-  Timer? _filterNameTimer;
-
-// The controller for the font family PageView.
-  late PageController _familyPageController;
-
-// The controller for the text colors PageView.
-  late PageController _textColorsPageController;
-
-// The controller for the gradients PageView.
-  late PageController _gradientsPageController;
-
-// The controller for the color filters PageView.
-  late PageController _colorFiltersPageController;
-
-// The controller for the text editing field.
-  final _editingController = TextEditingController();
-
-// The stack data for the editable items.
-  final _stackData = <EditableItem>[];
+  late final StoryMakerController _ctrl;
 
   /// Gets the font list to use (custom or default).
   List<String> get _fontList => widget.customFontList ?? fontFamilyList;
@@ -172,66 +82,27 @@ class _StoryMakerState extends State<StoryMaker> {
     if (widget.customStickers != null) {
       return widget.customStickers!;
     }
-    // Convert default emoji strings to StickerItem.emoji
-    return defaultStickers.map((emoji) => StickerItem.emoji(emoji)).toList();
+    return defaultStickers.map(StickerItem.emoji).toList();
   }
 
   /// Gets the theme to use (custom or default).
   StoryMakerTheme get _theme => widget.theme ?? StoryMakerTheme.defaultTheme();
 
   @override
-
-  /// Called when this object is inserted into the tree.
-  ///
-  /// The framework will call this method exactly once for each [State] object it creates.
-  /// This method is where you should put any expensive computations, network calls, initializations, or subscriptions.
-  /// In this case, it calls the [_init] method to initialize the state of the widget.
   void initState() {
     super.initState();
-    _init();
+    _ctrl = StoryMakerController(
+      filePath: widget.filePath,
+      fontList: _fontList,
+      textColors: _textColors,
+      gradients: _gradients,
+    );
   }
 
   @override
-
-  /// Called when this object is removed from the tree permanently.
-  ///
-  /// The framework calls this method when this [State] object will never build again.
-  /// This method is where you should unsubscribe or dispose any resources, streams, or animations that were created in [initState].
   void dispose() {
-    _editingController.dispose();
-    _familyPageController.dispose();
-    _textColorsPageController.dispose();
-    _gradientsPageController.dispose();
-    _colorFiltersPageController.dispose();
-    _styleNameTimer?.cancel();
-    _filterNameTimer?.cancel();
+    _ctrl.dispose();
     super.dispose();
-  }
-
-  /// Initializes the state of the widget.
-  ///
-  /// This method is called in [initState] to set up the initial state of the widget.
-  /// It initializes the [_stackData] with an [EditableItem] of type [ItemType.IMAGE] and the value of [widget.filePath].
-  /// It also initializes the [_familyPageController], [_textColorsPageController], and [_gradientsPageController] with their respective viewport fractions.
-  void _init() {
-    _stackData.add(
-      EditableItem()
-        ..type = ItemType.IMAGE
-        ..value = widget.filePath,
-    );
-    _familyPageController = PageController(
-      viewportFraction: ViewportFractions.fontFamily,
-    );
-    _textColorsPageController = PageController(
-      viewportFraction: ViewportFractions.textColors,
-    );
-    _gradientsPageController = PageController(
-      viewportFraction: ViewportFractions.gradients,
-    );
-    _colorFiltersPageController = PageController(
-      viewportFraction: 0.15,
-      initialPage: _selectedColorFilter.index,
-    );
   }
 
   @override
@@ -248,255 +119,15 @@ class _StoryMakerState extends State<StoryMaker> {
           body: Stack(
             clipBehavior: Clip.antiAlias,
             children: [
-              Positioned(
-                top: context.topPadding,
-                left: 0,
-                right: 0,
-                child: ClipRRect(
-                  borderRadius:
-                      BorderRadius.circular(_theme.safeAreaBorderRadius),
-                  child: AspectRatio(
-                    aspectRatio: StoryConstants.aspectRatio,
-                    child: GestureDetector(
-                      onScaleStart: _onScaleStart,
-                      onScaleUpdate: _onScaleUpdate,
-                      onTap: _onScreenTap,
-                      onHorizontalDragEnd: _onHorizontalDragEnd,
-                      child: Stack(
-                        children: [
-                          RepaintBoundary(
-                            key: previewContainer,
-                            child: Stack(
-                              children: [
-                                Visibility(
-                                  visible: _stackData[0].type == ItemType.IMAGE,
-                                  child: Center(
-                                    child: ColorFiltered(
-                                      colorFilter: ColorFilter.matrix(
-                                        getColorFilterMatrix(
-                                          _selectedColorFilter,
-                                        ),
-                                      ),
-                                      child: PhotoView(
-                                        enableRotation: true,
-                                        backgroundDecoration: BoxDecoration(
-                                          gradient: LinearGradient(
-                                            begin: FractionalOffset.topLeft,
-                                            end: FractionalOffset.centerRight,
-                                            colors: _gradients[
-                                                _selectedBackgroundGradient],
-                                          ),
-                                        ),
-                                        maxScale: 2.0,
-                                        enablePanAlways: false,
-                                        imageProvider: FileImage(
-                                          File(_stackData[0].value),
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                ..._stackData.map(
-                                  (editableItem) => OverlayItemWidget(
-                                    editableItem: editableItem,
-                                    onItemTap: () {
-                                      _onOverlayItemTap(editableItem);
-                                    },
-                                    onPointerDown: (details) {
-                                      _onOverlayItemPointerDown(
-                                        editableItem,
-                                        details,
-                                      );
-                                    },
-                                    onPointerUp: (details) {
-                                      _onOverlayItemPointerUp(
-                                        editableItem,
-                                        details,
-                                      );
-                                    },
-                                    onPointerMove: (details) {
-                                      _onOverlayItemPointerMove(
-                                        editableItem,
-                                        details,
-                                      );
-                                    },
-                                    fontList: _fontList,
-                                    gradients: _gradients,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          AnimatedSwitcher(
-                            duration: widget.animationsDuration,
-                            child: !_isTextInput
-                                ? const SizedBox()
-                                : Container(
-                                    height: context.height,
-                                    width: context.width,
-                                    color: Colors.black.withValues(alpha: 0.4),
-                                    child: Stack(
-                                      children: [
-                                        TextFieldWidget(
-                                          controller: _editingController,
-                                          onChanged: _onTextChange,
-                                          onSubmit: _onTextSubmit,
-                                          fontSize: _selectedFontSize,
-                                          fontFamilyIndex: _selectedFontFamily,
-                                          textColor: _selectedTextColor,
-                                          backgroundColorIndex:
-                                              _selectedTextBackgroundGradient,
-                                          fontList: _fontList,
-                                          gradients: _gradients,
-                                        ),
-                                        SizeSliderWidget(
-                                          animationsDuration:
-                                              widget.animationsDuration,
-                                          selectedValue: _selectedFontSize,
-                                          onChanged: (input) {
-                                            setState(
-                                              () {
-                                                _selectedFontSize = input;
-                                              },
-                                            );
-                                          },
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              if (_isTextInput)
-                if (!_isColorPickerSelected)
-                  FontFamilySelectWidget(
-                    animationsDuration: widget.animationsDuration,
-                    pageController: _familyPageController,
-                    selectedFamilyIndex: _selectedFontFamily,
-                    onPageChanged: _onFamilyChange,
-                    onTap: (index) {
-                      _onStyleChange(index);
-                    },
-                    fontList: _fontList,
-                  )
-                else
-                  TextColorSelectWidget(
-                    animationsDuration: widget.animationsDuration,
-                    pageController: _textColorsPageController,
-                    selectedTextColor: _selectedTextColor,
-                    onPageChanged: _onTextColorChange,
-                    onTap: (index) {
-                      _onColorChange(index);
-                    },
-                    textColors: _textColors,
-                  ),
-              BackgroundGradientSelectorWidget(
-                isTextInput: _isTextInput,
-                isBackgroundColorPickerSelected:
-                    _isBackgroundColorPickerSelected,
-                inAction: _inAction,
-                animationsDuration: widget.animationsDuration,
-                gradientsPageController: _gradientsPageController,
-                onPageChanged: _onChangeBackgroundGradient,
-                onItemTap: _onBackgroundGradientTap,
-                selectedGradientIndex: _selectedBackgroundGradient,
-                gradients: _gradients,
-              ),
-              TopToolsWidget(
-                isTextInput: _isTextInput,
-                selectedBackgroundGradientIndex: _selectedBackgroundGradient,
-                animationsDuration: widget.animationsDuration,
-                onPickerTap: _onToggleBackgroundGradientPicker,
-                onScreenTap: _onScreenTap,
-                selectedTextBackgroundGradientIndex:
-                    _selectedTextBackgroundGradient,
-                onToggleTextColorPicker: _onToggleTextColorSelector,
-                onChangeTextBackground: _onChangeTextBackground,
-                gradients: _gradients,
-                activeItem: _activeItem,
-                onStickerTap: _onToggleStickerPicker,
-              ),
-              StickerSelectorWidget(
-                stickers: _stickers,
-                animationsDuration: widget.animationsDuration,
-                onStickerTap: _onStickerSelected,
-                isVisible:
-                    _isStickerPickerSelected && !_isTextInput && !_inAction,
-              ),
-              RemoveWidget(
-                isTextInput: _isTextInput,
-                animationsDuration: widget.animationsDuration,
-                activeItem: _activeItem,
-                isDeletePosition: _isDeletePosition,
-              ),
-              Align(
-                alignment: Alignment.bottomCenter,
-                child: FooterToolsWidget(
-                  onDone: _onDone,
-                  doneButtonChild: widget.doneButtonChild,
-                  isLoading: _isLoading,
-                  doneButtonBuilder: widget.doneButtonBuilder,
-                ),
-              ),
-              // Style name overlay - positioned at the end to appear on top
-              if (_displayedStyleName != null)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    child: Center(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 24,
-                          vertical: 12,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.black.withValues(alpha: 0.7),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Text(
-                          _displayedStyleName!,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 18,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              // Filter name overlay - positioned at the end to appear on top
-              if (_displayedFilterName != null)
-                Positioned.fill(
-                  child: IgnorePointer(
-                    child: Center(
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 24,
-                          vertical: 12,
-                        ),
-                        margin: EdgeInsets.only(
-                          bottom: context.bottomPadding,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.black.withValues(alpha: 0.7),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Text(
-                          _displayedFilterName!,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 24,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
+              _buildCanvasArea(),
+              _buildTextInputSelectors(),
+              _buildBackgroundGradientSelector(),
+              _buildTopTools(),
+              _buildStickerSelector(),
+              _buildRemoveWidget(),
+              _buildFooter(),
+              _buildStyleNameOverlay(),
+              _buildFilterNameOverlay(),
             ],
           ),
         ),
@@ -504,550 +135,465 @@ class _StoryMakerState extends State<StoryMaker> {
     );
   }
 
-  /// Handles the submission of text input.
-  ///
-  /// This method is called when the user submits the text input field.
-  /// If the input is not empty, it calls the [_onSubmitText] method to add the text to the stack data.
-  /// If the input is empty, it resets the [_currentText] to an empty string.
-  /// In either case, it toggles the [_isTextInput] flag to exit the text input mode and sets the [_activeItem] to null.
-  void _onTextSubmit(String input) {
-    if (input.isNotEmpty) {
-      setState(
-        _onSubmitText,
-      );
-    } else {
-      setState(() {
-        _currentText = '';
-      });
-    }
+  // ---------------------------------------------------------------------------
+  // Canvas area — image + overlay items + text input
+  // ---------------------------------------------------------------------------
 
-    setState(
-      () {
-        _isTextInput = !_isTextInput;
-        _activeItem = null;
+  Widget _buildCanvasArea() {
+    return Positioned(
+      top: context.topPadding,
+      left: 0,
+      right: 0,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(_theme.safeAreaBorderRadius),
+        child: AspectRatio(
+          aspectRatio: StoryConstants.aspectRatio,
+          child: GestureDetector(
+            onScaleStart: _ctrl.onScaleStart,
+            onScaleUpdate: (details) {
+              _ctrl.onScaleUpdate(
+                details,
+                Size(context.width, context.height),
+              );
+            },
+            onTap: _ctrl.onScreenTap,
+            onHorizontalDragEnd: (details) {
+              _ctrl.onHorizontalDragEnd(
+                details,
+                hasActiveItem: _ctrl.activeItem.value != null,
+              );
+            },
+            child: Stack(
+              children: [
+                RepaintBoundary(
+                  key: _previewContainer,
+                  child: ValueListenableBuilder<List<EditableItem>>(
+                    valueListenable: _ctrl.stackData,
+                    builder: (context, items, _) {
+                      return ValueListenableBuilder<ColorFilterType>(
+                        valueListenable: _ctrl.selectedColorFilter,
+                        builder: (context, filter, _) {
+                          return ValueListenableBuilder<int>(
+                            valueListenable:
+                                _ctrl.selectedBackgroundGradient,
+                            builder: (context, bgGradient, _) {
+                              return Stack(
+                                children: [
+                                  _buildImageLayer(
+                                    items,
+                                    filter,
+                                    bgGradient,
+                                  ),
+                                  ...items.map(
+                                    (item) => OverlayItemWidget(
+                                      key: ValueKey<int>(item.hashCode),
+                                      editableItem: item,
+                                      onItemTap: () =>
+                                          _ctrl.onOverlayItemTap(item),
+                                      onPointerDown: (details) =>
+                                          _ctrl.onOverlayItemPointerDown(
+                                        item,
+                                        details,
+                                      ),
+                                      onPointerUp: (details) =>
+                                          _ctrl.onOverlayItemPointerUp(
+                                        item,
+                                        details,
+                                      ),
+                                      onPointerMove: (details) =>
+                                          _ctrl.onOverlayItemPointerMove(
+                                        item,
+                                        details,
+                                      ),
+                                      fontList: _fontList,
+                                      gradients: _gradients,
+                                    ),
+                                  ),
+                                ],
+                              );
+                            },
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+                _buildTextInputOverlay(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildImageLayer(
+    List<EditableItem> items,
+    ColorFilterType filter,
+    int bgGradient,
+  ) {
+    if (items.isEmpty || items[0].type != ItemType.IMAGE) {
+      return const SizedBox();
+    }
+    return Center(
+      child: ColorFiltered(
+        colorFilter: ColorFilter.matrix(filter.matrix),
+        child: PhotoView(
+          enableRotation: true,
+          backgroundDecoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: FractionalOffset.topLeft,
+              end: FractionalOffset.centerRight,
+              colors: _gradients[bgGradient],
+            ),
+          ),
+          maxScale: 2.0,
+          enablePanAlways: false,
+          imageProvider: FileImage(File(items[0].value)),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTextInputOverlay() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _ctrl.isTextInput,
+      builder: (context, textInput, _) {
+        return AnimatedSwitcher(
+          duration: widget.animationsDuration,
+          child: !textInput
+              ? const SizedBox()
+              : Container(
+                  height: context.height,
+                  width: context.width,
+                  color: Colors.black.withValues(alpha: 0.4),
+                  child: Stack(
+                    children: [
+                      ValueListenableBuilder<double>(
+                        valueListenable: _ctrl.selectedFontSize,
+                        builder: (context, fontSize, _) {
+                          return ValueListenableBuilder<int>(
+                            valueListenable: _ctrl.selectedFontFamily,
+                            builder: (context, fontFamily, _) {
+                              return ValueListenableBuilder<Color>(
+                                valueListenable: _ctrl.selectedTextColor,
+                                builder: (context, textColor, _) {
+                                  return ValueListenableBuilder<int>(
+                                    valueListenable: _ctrl
+                                        .selectedTextBackgroundGradient,
+                                    builder: (context, bgGradient, _) {
+                                      return TextFieldWidget(
+                                        controller: _ctrl.editingController,
+                                        onChanged: _ctrl.onTextChange,
+                                        onSubmit: _ctrl.onTextSubmit,
+                                        fontSize: fontSize,
+                                        fontFamilyIndex: fontFamily,
+                                        textColor: textColor,
+                                        backgroundColorIndex: bgGradient,
+                                        fontList: _fontList,
+                                        gradients: _gradients,
+                                      );
+                                    },
+                                  );
+                                },
+                              );
+                            },
+                          );
+                        },
+                      ),
+                      ValueListenableBuilder<double>(
+                        valueListenable: _ctrl.selectedFontSize,
+                        builder: (context, fontSize, _) {
+                          return SizeSliderWidget(
+                            animationsDuration: widget.animationsDuration,
+                            selectedValue: fontSize,
+                            onChanged: (input) {
+                              _ctrl.selectedFontSize.value = input;
+                            },
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+        );
       },
     );
   }
 
-  /// Handles the change of text input.
-  ///
-  /// This method is called when the user types into the text input field.
-  /// It updates the [_currentText] with the new input.
-  void _onTextChange(input) {
-    setState(() {
-      _currentText = input;
-    });
-  }
+  // ---------------------------------------------------------------------------
+  // Text input selectors (font family / text color)
+  // ---------------------------------------------------------------------------
 
-  /// Changes the background of the text.
-  ///
-  /// This method is called when the user taps on the text background change button.
-  /// It increments the [_selectedTextBackgroundGradient] index if it's less than the length of gradients array.
-  /// If the index has reached the end of the array, it resets it to 0.
-  void _onChangeTextBackground() {
-    if (_selectedTextBackgroundGradient < _gradients.length - 1) {
-      setState(() {
-        _selectedTextBackgroundGradient++;
-      });
-    } else {
-      setState(() {
-        _selectedTextBackgroundGradient = 0;
-      });
-    }
-  }
-
-  /// Toggles the text color selector.
-  ///
-  /// This method is called when the user taps on the text color selector button.
-  /// It toggles the [_isColorPickerSelected] flag to show or hide the color picker.
-  void _onToggleTextColorSelector() {
-    setState(
-      () {
-        _isColorPickerSelected = !_isColorPickerSelected;
+  Widget _buildTextInputSelectors() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _ctrl.isTextInput,
+      builder: (context, textInput, _) {
+        if (!textInput) return const SizedBox();
+        return ValueListenableBuilder<bool>(
+          valueListenable: _ctrl.isColorPickerSelected,
+          builder: (context, colorPicker, _) {
+            if (!colorPicker) {
+              return ValueListenableBuilder<int>(
+                valueListenable: _ctrl.selectedFontFamily,
+                builder: (context, familyIndex, _) {
+                  return FontFamilySelectWidget(
+                    animationsDuration: widget.animationsDuration,
+                    pageController: _ctrl.familyPageController,
+                    selectedFamilyIndex: familyIndex,
+                    onPageChanged: _ctrl.onFamilyChange,
+                    onTap: _ctrl.onStyleChange,
+                    fontList: _fontList,
+                  );
+                },
+              );
+            }
+            return ValueListenableBuilder<Color>(
+              valueListenable: _ctrl.selectedTextColor,
+              builder: (context, textColor, _) {
+                return TextColorSelectWidget(
+                  animationsDuration: widget.animationsDuration,
+                  pageController: _ctrl.textColorsPageController,
+                  selectedTextColor: textColor,
+                  onPageChanged: _ctrl.onTextColorChange,
+                  onTap: _ctrl.onColorChange,
+                  textColors: _textColors,
+                );
+              },
+            );
+          },
+        );
       },
     );
   }
 
-  /// Handles the change of text color.
-  ///
-  /// This method is called when the user selects a new text color from the color picker.
-  /// It updates the [_selectedTextColor] with the new color.
-  /// The [index] parameter is the index of the selected color in the text colors list.
-  void _onTextColorChange(index) {
-    HapticFeedback.lightImpact();
-    setState(
-      () {
-        _selectedTextColor = _textColors[index];
+  // ---------------------------------------------------------------------------
+  // Background gradient selector
+  // ---------------------------------------------------------------------------
+
+  Widget _buildBackgroundGradientSelector() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _ctrl.isTextInput,
+      builder: (context, textInput, _) {
+        return ValueListenableBuilder<bool>(
+          valueListenable: _ctrl.isBackgroundColorPickerSelected,
+          builder: (context, bgPickerSelected, _) {
+            return ValueListenableBuilder<int>(
+              valueListenable: _ctrl.selectedBackgroundGradient,
+              builder: (context, gradientIndex, _) {
+                return BackgroundGradientSelectorWidget(
+                  isTextInput: textInput,
+                  isBackgroundColorPickerSelected: bgPickerSelected,
+                  inAction: _ctrl.inAction,
+                  animationsDuration: widget.animationsDuration,
+                  gradientsPageController: _ctrl.gradientsPageController,
+                  onPageChanged: _ctrl.onChangeBackgroundGradient,
+                  onItemTap: _ctrl.onBackgroundGradientTap,
+                  selectedGradientIndex: gradientIndex,
+                  gradients: _gradients,
+                );
+              },
+            );
+          },
+        );
       },
     );
   }
 
-  /// Handles the change of font family.
-  ///
-  /// This method is called when the user selects a new font family from the font family picker.
-  /// It updates the [_selectedFontFamily] with the new font family.
-  /// The [index] parameter is the index of the selected font family in the [fontFamilyList] list.
-  void _onFamilyChange(index) {
-    HapticFeedback.lightImpact();
-    setState(() {
-      _selectedFontFamily = index;
-    });
-  }
+  // ---------------------------------------------------------------------------
+  // Top tools
+  // ---------------------------------------------------------------------------
 
-  /// Toggles the background gradient picker.
-  ///
-  /// This method is called when the user taps on the background gradient picker button.
-  /// It toggles the [_isBackgroundColorPickerSelected] flag to show or hide the background gradient picker.
-  void _onToggleBackgroundGradientPicker() {
-    setState(
-      () {
-        _isBackgroundColorPickerSelected = !_isBackgroundColorPickerSelected;
-        _isStickerPickerSelected = false;
-        _isColorFilterPickerSelected = false;
+  Widget _buildTopTools() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _ctrl.isTextInput,
+      builder: (context, textInput, _) {
+        return ValueListenableBuilder<int>(
+          valueListenable: _ctrl.selectedBackgroundGradient,
+          builder: (context, bgGradient, _) {
+            return ValueListenableBuilder<int>(
+              valueListenable: _ctrl.selectedTextBackgroundGradient,
+              builder: (context, textBgGradient, _) {
+                return ValueListenableBuilder<EditableItem?>(
+                  valueListenable: _ctrl.activeItem,
+                  builder: (context, active, _) {
+                    return TopToolsWidget(
+                      isTextInput: textInput,
+                      selectedBackgroundGradientIndex: bgGradient,
+                      animationsDuration: widget.animationsDuration,
+                      onPickerTap: _ctrl.onToggleBackgroundGradientPicker,
+                      onScreenTap: _ctrl.onScreenTap,
+                      selectedTextBackgroundGradientIndex: textBgGradient,
+                      onToggleTextColorPicker:
+                          _ctrl.onToggleTextColorSelector,
+                      onChangeTextBackground:
+                          _ctrl.onChangeTextBackground,
+                      gradients: _gradients,
+                      activeItem: active,
+                      onStickerTap: _ctrl.onToggleStickerPicker,
+                    );
+                  },
+                );
+              },
+            );
+          },
+        );
       },
     );
   }
 
-  /// Toggles the sticker picker.
-  ///
-  /// This method is called when the user taps on the sticker button.
-  /// It toggles the [_isStickerPickerSelected] flag to show or hide the sticker picker.
-  void _onToggleStickerPicker() {
-    setState(
-      () {
-        _isStickerPickerSelected = !_isStickerPickerSelected;
-        _isBackgroundColorPickerSelected = false;
-        _isColorFilterPickerSelected = false;
-        _isTextInput = false;
-        _activeItem = null;
+  // ---------------------------------------------------------------------------
+  // Sticker selector
+  // ---------------------------------------------------------------------------
+
+  Widget _buildStickerSelector() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _ctrl.isStickerPickerSelected,
+      builder: (context, stickerPicker, _) {
+        return ValueListenableBuilder<bool>(
+          valueListenable: _ctrl.isTextInput,
+          builder: (context, textInput, _) {
+            return StickerSelectorWidget(
+              stickers: _stickers,
+              animationsDuration: widget.animationsDuration,
+              onStickerTap: _ctrl.onStickerSelected,
+              isVisible: stickerPicker && !textInput && !_ctrl.inAction,
+            );
+          },
+        );
       },
     );
   }
 
-  /// Toggles the color filter picker.
-  ///
-  /// This method is called when the user taps on the color filter button.
-  /// It toggles the [_isColorFilterPickerSelected] flag to show or hide the color filter picker.
-  // ignore: unused_element
-  void _onToggleColorFilterPicker() {
-    setState(
-      () {
-        _isColorFilterPickerSelected = !_isColorFilterPickerSelected;
-        _isBackgroundColorPickerSelected = false;
-        _isStickerPickerSelected = false;
-        _isTextInput = false;
-        _activeItem = null;
+  // ---------------------------------------------------------------------------
+  // Remove widget
+  // ---------------------------------------------------------------------------
+
+  Widget _buildRemoveWidget() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _ctrl.isTextInput,
+      builder: (context, textInput, _) {
+        return ValueListenableBuilder<EditableItem?>(
+          valueListenable: _ctrl.activeItem,
+          builder: (context, active, _) {
+            return ValueListenableBuilder<bool>(
+              valueListenable: _ctrl.isDeletePosition,
+              builder: (context, deletePos, _) {
+                return RemoveWidget(
+                  isTextInput: textInput,
+                  animationsDuration: widget.animationsDuration,
+                  activeItem: active,
+                  isDeletePosition: deletePos,
+                );
+              },
+            );
+          },
+        );
       },
     );
   }
 
-  /// Handles color filter selection.
-  ///
-  /// This method is called when the user selects a color filter.
-  /// It updates the [_selectedColorFilter] with the new filter.
-  // ignore: unused_element
-  void _onColorFilterSelected(ColorFilterType filter) {
-    HapticFeedback.lightImpact();
+  // ---------------------------------------------------------------------------
+  // Footer
+  // ---------------------------------------------------------------------------
 
-    // Cancel previous timer if exists
-    _filterNameTimer?.cancel();
-
-    // Get the filter name
-    final filterName = getFilterName(filter);
-
-    setState(() {
-      _selectedColorFilter = filter;
-      _isColorFilterPickerSelected = false;
-      _displayedFilterName = filterName;
-    });
-
-    log('filterName: $filterName');
-
-    // Hide the filter name after 2 seconds
-    _filterNameTimer = Timer(const Duration(seconds: 2), () {
-      if (mounted) {
-        setState(() {
-          _displayedFilterName = null;
-        });
-      }
-    });
-
-    // Only jump to page if PageController is attached
-    if (_colorFiltersPageController.hasClients) {
-      _colorFiltersPageController.jumpToPage(filter.index);
-    }
+  Widget _buildFooter() {
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: ValueListenableBuilder<bool>(
+        valueListenable: _ctrl.isLoading,
+        builder: (context, loading, _) {
+          return FooterToolsWidget(
+            onDone: _onDone,
+            doneButtonChild: widget.doneButtonChild,
+            isLoading: loading,
+            doneButtonBuilder: widget.doneButtonBuilder,
+          );
+        },
+      ),
+    );
   }
 
-  /// Handles horizontal drag end (swipe) to change filters.
-  ///
-  /// This method is called when the user swipes horizontally on the image.
-  /// It changes the filter to the next or previous one based on the swipe direction.
-  void _onHorizontalDragEnd(DragEndDetails details) {
-    // Only handle swipe if not in action (moving/editing items) and not in text input
-    if (_inAction || _isTextInput || _activeItem != null) {
-      return;
-    }
+  // ---------------------------------------------------------------------------
+  // Overlay name displays
+  // ---------------------------------------------------------------------------
 
-    final velocity = details.velocity.pixelsPerSecond.dx;
-    const threshold = 300.0; // Minimum velocity to trigger filter change
-
-    if (velocity.abs() > threshold) {
-      const filters = ColorFilterType.values;
-      final currentIndex = _selectedColorFilter.index;
-
-      // Cancel previous timer if exists
-      _filterNameTimer?.cancel();
-
-      if (velocity > 0) {
-        // Swipe right - next filter
-        final nextIndex = (currentIndex + 1) % filters.length;
-        final filter = filters[nextIndex];
-        final filterName = getFilterName(filter);
-
-        HapticFeedback.lightImpact();
-        setState(() {
-          _selectedColorFilter = filter;
-          _displayedFilterName = filterName;
-        });
-
-        // Hide the filter name after 2 seconds
-        _filterNameTimer = Timer(const Duration(seconds: 2), () {
-          if (mounted) {
-            setState(() {
-              _displayedFilterName = null;
-            });
-          }
-        });
-
-        // Only jump to page if PageController is attached
-        if (_colorFiltersPageController.hasClients) {
-          _colorFiltersPageController.jumpToPage(nextIndex);
-        }
-      } else {
-        // Swipe left - previous filter
-        final prevIndex = (currentIndex - 1 + filters.length) % filters.length;
-        final filter = filters[prevIndex];
-        final filterName = getFilterName(filter);
-
-        HapticFeedback.lightImpact();
-        setState(() {
-          _selectedColorFilter = filter;
-          _displayedFilterName = filterName;
-        });
-
-        // Hide the filter name after 2 seconds
-        _filterNameTimer = Timer(const Duration(seconds: 5), () {
-          if (mounted) {
-            setState(() {
-              _displayedFilterName = null;
-            });
-          }
-        });
-
-        // Only jump to page if PageController is attached
-        if (_colorFiltersPageController.hasClients) {
-          _colorFiltersPageController.jumpToPage(prevIndex);
-        }
-      }
-    }
-  }
-
-  /// Handles sticker selection.
-  ///
-  /// This method is called when the user selects a sticker from the sticker picker.
-  /// It adds a new [EditableItem] of type [ItemType.STICKER] to the [_stackData].
-  void _onStickerSelected(StickerItem sticker) {
-    setState(() {
-      _stackData.add(
-        EditableItem()
-          ..type = ItemType.STICKER
-          ..value = sticker.value
-          ..fontSize = FontSizeConstants.defaultValue,
-      );
-      _isStickerPickerSelected = false;
-    });
-  }
-
-  /// Handles the selection of a background gradient.
-  ///
-  /// This method is called when the user selects a new background gradient from the gradient picker.
-  /// It updates the [_selectedBackgroundGradient] with the new gradient and jumps the [_gradientsPageController] to the selected page.
-  /// The [index] parameter is the index of the selected gradient in the [gradientColors] list.
-  void _onBackgroundGradientTap(index) {
-    setState(
-      () {
-        _selectedBackgroundGradient = index;
-        _gradientsPageController.jumpToPage(index);
+  Widget _buildStyleNameOverlay() {
+    return ValueListenableBuilder<String?>(
+      valueListenable: _ctrl.displayedStyleName,
+      builder: (context, styleName, _) {
+        if (styleName == null) return const SizedBox();
+        return _buildNameOverlay(
+          name: styleName,
+          fontSize: 18,
+        );
       },
     );
   }
 
-  /// Handles the change of background gradient.
-  ///
-  /// This method is called when the user selects a new background gradient from the gradient picker.
-  /// It updates the [_selectedBackgroundGradient] with the new gradient.
-  /// The [index] parameter is the index of the selected gradient in the [gradientColors] list.
-  void _onChangeBackgroundGradient(index) {
-    HapticFeedback.lightImpact();
-    setState(
-      () {
-        _selectedBackgroundGradient = index;
+  Widget _buildFilterNameOverlay() {
+    return ValueListenableBuilder<String?>(
+      valueListenable: _ctrl.displayedFilterName,
+      builder: (context, filterName, _) {
+        if (filterName == null) return const SizedBox();
+        return _buildNameOverlay(
+          name: filterName,
+          fontSize: 24,
+          bottomMargin: context.bottomPadding,
+        );
       },
     );
   }
 
-  /// Handles the start of a scale gesture.
-  ///
-  /// This method is called when the user starts a scale gesture on the active item.
-  /// It sets the [_initPos], [_currentPos], [_currentScale], and [_currentRotation] to the initial values of the gesture.
-  /// The [details] parameter contains the details of the scale start gesture.
-  void _onScaleStart(ScaleStartDetails details) {
-    if (_activeItem == null) {
-      return;
-    }
-    _initPos = details.focalPoint;
-    _currentPos = _activeItem!.position;
-    _currentScale = _activeItem!.scale;
-    _currentRotation = _activeItem!.rotation;
-  }
-
-  /// Handles the update of a scale gesture.
-  ///
-  /// This method is called when the user updates a scale gesture on the active item.
-  /// It calculates the new position, rotation, and scale of the active item based on the gesture details and updates the state.
-  /// The [details] parameter contains the details of the scale update gesture.
-  void _onScaleUpdate(ScaleUpdateDetails details) {
-    if (_activeItem == null) {
-      return;
-    }
-    final delta = details.focalPoint - _initPos;
-    final left = (delta.dx / context.width) + _currentPos.dx;
-    final top = (delta.dy / context.height) + _currentPos.dy;
-
-    setState(() {
-      _activeItem!.position = Offset(left, top);
-      _activeItem!.rotation = details.rotation + _currentRotation;
-      _activeItem!.scale = details.scale * _currentScale;
-    });
-  }
-
-  /// Handles the screen tap event.
-  ///
-  /// This method is called when the user taps on the screen.
-  /// It toggles the [_isTextInput] flag to enter or exit the text input mode and sets the [_activeItem] to null.
-  /// If the current text is not empty, it calls the [_onSubmitText] method to add the text to the stack data.
-  /// It also initializes the [_familyPageController] and [_textColorsPageController] with their respective viewport fractions.
-  void _onScreenTap() {
-    setState(() {
-      _isTextInput = !_isTextInput;
-      _activeItem = null;
-      _isBackgroundColorPickerSelected = false;
-      _isStickerPickerSelected = false;
-    });
-
-    if (_currentText.isNotEmpty) {
-      setState(_onSubmitText);
-    }
-    _familyPageController.dispose();
-    _textColorsPageController.dispose();
-    _familyPageController = PageController(
-      initialPage: _selectedFontFamily,
-      viewportFraction: ViewportFractions.fontFamily,
-    );
-    _textColorsPageController = PageController(
-      initialPage:
-          _textColors.indexWhere((element) => element == _selectedTextColor),
-      viewportFraction: ViewportFractions.textColors,
+  Widget _buildNameOverlay({
+    required String name,
+    required double fontSize,
+    double bottomMargin = 0,
+  }) {
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 24,
+              vertical: 12,
+            ),
+            margin: EdgeInsets.only(bottom: bottomMargin),
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.7),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Text(
+              name,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: fontSize,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 
-  /// Handles the done event.
-  ///
-  /// This method is called when the user taps on the done button.
-  /// It captures the current state of the widget as an image and saves it to the application documents directory.
-  /// The image is saved as a png file with the current date and time as the file name.
-  /// After the image is saved, it navigates back and passes the image file as the result of the navigation.
+  // ---------------------------------------------------------------------------
+  // Done action (image export) — needs BuildContext and mounted check
+  // ---------------------------------------------------------------------------
+
   Future<void> _onDone() async {
-    final boundary = previewContainer.currentContext!.findRenderObject()
+    final boundary = _previewContainer.currentContext!.findRenderObject()
         as RenderRepaintBoundary?;
-    setState(() {
-      _isLoading = true;
-    });
+    _ctrl.isLoading.value = true;
     final image = await boundary!.toImage(pixelRatio: 3);
     final directory = (await getApplicationDocumentsDirectory()).path;
     final byteData = (await image.toByteData(format: ui.ImageByteFormat.png))!;
     final pngBytes = byteData.buffer.asUint8List();
     final imgFile = File('$directory/${DateTime.now()}.png');
     await imgFile.writeAsBytes(pngBytes);
-    if (mounted) {
-      setState(() {
-        _isLoading = false;
-      });
-    }
+    _ctrl.isLoading.value = false;
     if (mounted) {
       Navigator.of(context).pop(imgFile);
-    }
-  }
-
-  /// Handles the submission of text input.
-  ///
-  /// This method is called when the user submits the text input field.
-  /// It adds a new [EditableItem] of type [ItemType.TEXT] to the [_stackData] with the current text, text color, text style, font size, and font family.
-  /// It then resets the [_editingController] and [_currentText] to an empty string.
-  void _onSubmitText() {
-    _stackData.add(
-      EditableItem()
-        ..type = ItemType.TEXT
-        ..value = _currentText
-        ..color = _selectedTextColor
-        ..textStyle = _selectedTextBackgroundGradient
-        ..fontSize = _selectedFontSize
-        ..fontFamily = _selectedFontFamily,
-    );
-    _editingController.text = '';
-    _currentText = '';
-  }
-
-  /// Handles the change of font style.
-  ///
-  /// This method is called when the user selects a new font style from the style picker.
-  /// It updates the [_selectedFontFamily] with the new style and jumps the [_familyPageController] to the selected page.
-  /// The [index] parameter is the index of the selected style in the [fontFamilyList] list.
-  void _onStyleChange(int index) {
-    HapticFeedback.lightImpact();
-
-    // Cancel previous timer if exists
-    _styleNameTimer?.cancel();
-
-    // Get the style name
-    final styleName = _fontList[index];
-
-    setState(() {
-      _selectedFontFamily = index;
-      _displayedStyleName = styleName;
-    });
-
-    // Hide the style name after 2 seconds
-    _styleNameTimer = Timer(const Duration(seconds: 2), () {
-      if (mounted) {
-        setState(() {
-          _displayedStyleName = null;
-        });
-      }
-    });
-
-    if (_familyPageController.hasClients) {
-      _familyPageController.jumpToPage(index);
-    }
-  }
-
-  /// Handles the change of text color.
-  ///
-  /// This method is called when the user selects a new text color from the color picker.
-  /// It updates the [_selectedTextColor] with the new color and jumps the [_textColorsPageController] to the selected page.
-  /// The [index] parameter is the index of the selected color in the text colors list.
-  void _onColorChange(int index) {
-    HapticFeedback.lightImpact();
-    setState(() {
-      _selectedTextColor = _textColors[index];
-    });
-    _textColorsPageController.jumpToPage(index);
-  }
-
-  /// Handles the tap event on an overlay item.
-  ///
-  /// This method is called when the user taps on an overlay item.
-  /// It toggles the [_isTextInput] flag to enter or exit the text input mode, sets the [_activeItem] to null, and updates the text and style properties based on the tapped item.
-  /// It also removes the tapped item from the [_stackData] and initializes the [_familyPageController] and [_textColorsPageController] with their respective viewport fractions.
-  /// The [e] parameter is the tapped [EditableItem].
-  void _onOverlayItemTap(EditableItem e) {
-    setState(
-      () {
-        _isTextInput = !_isTextInput;
-        _activeItem = null;
-        _editingController.text = e.value;
-        _currentText = e.value;
-        _selectedFontFamily = e.fontFamily;
-        _selectedFontSize = e.fontSize;
-        _selectedTextBackgroundGradient = e.textStyle;
-        _selectedTextColor = e.color;
-        _stackData.removeAt(_stackData.indexOf(e));
-      },
-    );
-    _familyPageController.dispose();
-    _textColorsPageController.dispose();
-    _familyPageController = PageController(
-      initialPage: e.fontFamily,
-      viewportFraction: ViewportFractions.fontFamily,
-    );
-    _textColorsPageController = PageController(
-      initialPage: _textColors.indexWhere(
-        (element) => element == e.color,
-      ),
-      viewportFraction: ViewportFractions.textColors,
-    );
-  }
-
-  /// Handles the pointer down event on an overlay item.
-  ///
-  /// This method is called when the user starts a pointer down gesture on an overlay item.
-  /// If the item is not an image and the widget is not in action, it sets the [_inAction] flag to true and updates the initial values of the gesture.
-  /// The [e] parameter is the [EditableItem] on which the gesture started.
-  /// The [details] parameter contains the details of the pointer down gesture.
-  void _onOverlayItemPointerDown(EditableItem e, PointerDownEvent details) {
-    if (e.type != ItemType.IMAGE) {
-      if (_inAction) {
-        return;
-      }
-      _inAction = true;
-      _activeItem = e;
-      _initPos = details.position;
-      _currentPos = e.position;
-      _currentScale = e.scale;
-      _currentRotation = e.rotation;
-    }
-  }
-
-  /// Handles the pointer up event on an overlay item.
-  ///
-  /// This method is called when the user ends a pointer up gesture on an overlay item.
-  /// It sets the [_inAction] flag to false and checks if the item is in the delete position.
-  /// If the item is in the delete position, it removes the item from the [_stackData] and sets the [_activeItem] to null.
-  /// The [e] parameter is the [EditableItem] on which the gesture ended.
-  /// The [details] parameter contains the details of the pointer up gesture.
-  void _onOverlayItemPointerUp(EditableItem e, PointerUpEvent details) {
-    _inAction = false;
-    if (e.position.dy >= PositionConstants.deletePositionThreshold &&
-        e.position.dx >= 0.0 &&
-        e.position.dx <= 1.0) {
-      setState(() {
-        _stackData.removeAt(_stackData.indexOf(e));
-        _activeItem = null;
-      });
-    } else {
-      setState(() {
-        _activeItem = null;
-      });
-    }
-  }
-
-  /// Handles the pointer move event on an overlay item.
-  ///
-  /// This method is called when the user moves a pointer on an overlay item.
-  /// It checks if the item is in the delete position and updates the [_isDeletePosition] flag accordingly.
-  /// The [e] parameter is the [EditableItem] on which the pointer is moving.
-  /// The [details] parameter contains the details of the pointer move gesture.
-  void _onOverlayItemPointerMove(EditableItem e, PointerMoveEvent details) {
-    if (e.position.dy >= PositionConstants.deletePositionThreshold &&
-        e.position.dx >= 0.0 &&
-        e.position.dx <= 1.0) {
-      setState(() {
-        _isDeletePosition = true;
-      });
-    } else {
-      setState(() {
-        _isDeletePosition = false;
-      });
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Extract all mutable state into `StoryMakerController`** with 17 individual `ValueNotifier` instances, eliminating all 37 `setState()` calls. Each UI section uses `ValueListenableBuilder` so only the widgets that depend on a specific piece of state rebuild when it changes (gestures, text input, pickers, overlays all rebuild independently).
- **Make `EditableItem` immutable** with `@immutable`, `const` constructor, `copyWith()`, and proper `==`/`hashCode` — enabling reliable list diffing and preventing accidental mutation.
- **Move `ColorFilterType` logic into enum methods** (`.matrix`, `.displayName`), consolidate duplicated timer logic, fix a 5s-vs-2s timer bug on swipe-left, and remove duplicate stickers/gradients from constants.
- **Add comprehensive `CLAUDE.md`** documenting the new architecture, state management patterns, code conventions, and development workflows.

### Key performance improvements
| Before | After |
|---|---|
| 37 `setState()` → full widget rebuild every time | 0 `setState()` → scoped `ValueListenableBuilder` rebuilds |
| Gesture updates rebuild entire 270-line `build()` at 60fps | Gesture updates only rebuild the canvas stack |
| Every keystroke rebuilds all pickers, overlays, footer | Text input changes only rebuild the text field area |
| Monolithic 1053-line State class | Controller (510 lines) + thin widget (600 lines) with 9 focused builder methods |

### Files changed
| File | Change |
|---|---|
| `lib/controller/src/story_maker_controller.dart` | **New** — ValueNotifier state controller |
| `lib/controller/controller.dart` | **New** — barrel export |
| `lib/story_maker.dart` | Rewritten with controller + ValueListenableBuilder |
| `lib/models/src/editable_items.dart` | Immutable with copyWith/==/hashCode |
| `lib/constants/src/color_filters.dart` | Enum methods replace free functions |
| `lib/constants/src/stickers.dart` | Removed 4 duplicate emojis |
| `lib/constants/src/gradients.dart` | Removed 1 duplicate gradient |
| `CLAUDE.md` | New + updated with architecture docs |

## Test plan

- [ ] Verify `flutter analyze` passes with zero errors
- [ ] Run `flutter test` — existing tests should still pass
- [ ] Test in example app: pick image → apply filter (swipe + tap) → add text → change font/color/size → add sticker → drag/rotate/scale items → delete item → export
- [ ] Confirm gesture performance is smooth (no jank during drag/rotate/scale)
- [ ] Confirm filter swipe left and right both show name overlay for 2 seconds

https://claude.ai/code/session_016GJwicmoZHUawhxh4HMEfD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Sticker library reduced from 50+ to 48 items.
  * Gradient presets optimized and refined.

* **Refactor**
  * State management architecture restructured for improved app performance and stability.
  * Enhanced internal system efficiency and data handling throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->